### PR TITLE
backport MSS fixup for PBR

### DIFF
--- a/zones.c
+++ b/zones.c
@@ -586,7 +586,7 @@ print_interface_rule(struct fw3_ipt_handle *handle, struct fw3_state *state,
 			fw3_ipt_rule_comment(r, "Zone %s MTU fixing", zone->name);
 			fw3_ipt_rule_target(r, "TCPMSS");
 			fw3_ipt_rule_addarg(r, false, "--clamp-mss-to-pmtu", NULL);
-			fw3_ipt_rule_replace(r, "FORWARD");
+			fw3_ipt_rule_replace(r, "POSTROUTING");
 
 			r = fw3_ipt_rule_create(handle, &tcp, dev, NULL, sub, NULL);
 			fw3_ipt_rule_addarg(r, false, "--tcp-flags", "SYN,RST");


### PR DESCRIPTION
Seems fw3 with off-tree xt modules still has avid following
https://github.com/openwrt/openwrt/issues/12112#issuecomment-1875041045
Backport fw4 fix semantic
https://github.com/openwrt/firewall4/commit/698a53354fd280aae097efe08803c0c9a10c14c2 
i.e relocate outgoing MTU fixup to POST(PB)ROUTING
tested on 23.05.2 that expected rule is emitted by iptables nft and zz

Signed-Off-By: Andris PE <neandris@gmail.com>